### PR TITLE
feat: scaffold precomputation service foundation

### DIFF
--- a/convex/aggregations.ts
+++ b/convex/aggregations.ts
@@ -1,0 +1,76 @@
+import { mutation, query } from './_generated/server'
+import { v } from 'convex/values'
+
+export const getPrecomputedAggregation = query({
+  args: {
+    userId: v.string(),
+    aggregationType: v.string(),
+    filterHash: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity?.subject || identity.subject !== args.userId) {
+      throw new Error('UNAUTHORIZED')
+    }
+
+    const record = await ctx.db
+      .query('precomputed_aggregations')
+      .withIndex('by_user_type', (q) =>
+        q.eq('userId', args.userId).eq('aggregationType', args.aggregationType),
+      )
+      .filter((q) => q.eq(q.field('filterHash'), args.filterHash))
+      .first()
+
+    if (!record) {
+      return null
+    }
+
+    const isExpired = record.expiresAt ? new Date(record.expiresAt) < new Date() : false
+    if (isExpired) {
+      return null
+    }
+
+    return record
+  },
+})
+
+export const storePrecomputedAggregation = mutation({
+  args: {
+    userId: v.string(),
+    aggregationType: v.string(),
+    filterHash: v.string(),
+    data: v.any(),
+    computedAt: v.string(),
+    expiresAt: v.string(),
+    version: v.number(),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity?.subject || identity.subject !== args.userId) {
+      throw new Error('UNAUTHORIZED')
+    }
+
+    await ctx.db.insert('precomputed_aggregations', args)
+  },
+})
+
+export const logDataChange = mutation({
+  args: {
+    userId: v.string(),
+    changeType: v.string(),
+    recordCount: v.number(),
+    changedAt: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity?.subject || identity.subject !== args.userId) {
+      throw new Error('UNAUTHORIZED')
+    }
+
+    await ctx.db.insert('data_change_log', {
+      ...args,
+      processed: false,
+    })
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -88,5 +88,29 @@ export default defineSchema({
     contentText: v.optional(v.string()),
     contentJson: v.optional(v.any()),
   }).index('by_run', ['runId']),
+
+  precomputed_aggregations: defineTable({
+    userId: v.string(),
+    aggregationType: v.string(),
+    filterHash: v.string(),
+    data: v.any(),
+    computedAt: v.string(),
+    expiresAt: v.string(),
+    version: v.number(),
+    metadata: v.optional(v.any()),
+  })
+    .index('by_user_type', ['userId', 'aggregationType'])
+    .index('by_filter_hash', ['filterHash'])
+    .index('by_expires', ['expiresAt']),
+
+  data_change_log: defineTable({
+    userId: v.string(),
+    changeType: v.string(),
+    recordCount: v.number(),
+    changedAt: v.string(),
+    processed: v.boolean(),
+  })
+    .index('by_user_processed', ['userId', 'processed'])
+    .index('by_changed_at', ['changedAt']),
 })
 

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,0 +1,23 @@
+# Hooks Directory
+
+## Purpose
+React hooks that expose service-layer capabilities to components while maintaining consistent loading, error, and caching semantics.
+
+## Conventions
+- Hooks must be tree-shakeable and free of side effects outside React lifecycles.
+- Accept explicit dependency inputs (service instances, configuration) rather than importing singletons when possible.
+- Return typed result objects with `data`, `loading`, and `error` fields.
+- Use `useMemo` for derived values and `useEffect` for asynchronous fetching.
+- Keep hooks under 150 lines; extract helpers into adjacent files when necessary.
+
+## Testing
+- Add React Testing Library hooks tests under `tests/unit/hooks/`.
+- Mock service dependencies with lightweight fakes.
+- Cover loading, success, error, and revalidation paths.
+
+## Pitfalls
+1. Do not read from global state modules directly; rely on props/context.
+2. Do not swallow errors—surface them through the returned `error` state.
+3. Do not assume browser environment; guard against `window` usage for SSR.
+4. Avoid stale closures by listing all dependencies in effect hooks.
+5. Provide cleanup for subscriptions or polling timers.

--- a/hooks/useAggregation.ts
+++ b/hooks/useAggregation.ts
@@ -1,0 +1,18 @@
+import type { FilterOptions } from '@/lib/types'
+import type { AggregationType } from '@/services/types'
+import type { UsePrecomputedDataOptions, UsePrecomputedDataResult } from './usePrecomputedData'
+import { usePrecomputedData } from './usePrecomputedData'
+
+export interface UseAggregationParams<TData> {
+  userId: string | null | undefined
+  type: AggregationType
+  filters: FilterOptions
+  options?: UsePrecomputedDataOptions<TData>
+}
+
+export function useAggregation<TData>(
+  params: UseAggregationParams<TData>,
+): UsePrecomputedDataResult<TData> {
+  const { userId, type, filters, options } = params
+  return usePrecomputedData<TData>(userId, type, filters, options ?? {})
+}

--- a/hooks/usePrecomputedData.ts
+++ b/hooks/usePrecomputedData.ts
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { AggregationService } from '@/services/aggregation-service'
+import type {
+  AggregationServiceRequest,
+  AggregationSource,
+  AggregationType,
+} from '@/services/types'
+import { createFilterHash } from '@/services/types'
+import type { FilterOptions } from '@/lib/types'
+
+export interface UsePrecomputedDataOptions<TData> {
+  service?: AggregationService
+  fallbackCompute?: AggregationServiceRequest<TData>['fallbackCompute']
+  forceRefresh?: boolean
+}
+
+export interface UsePrecomputedDataResult<TData> {
+  data: TData | null
+  loading: boolean
+  error: string | null
+  lastUpdated: Date | null
+  source: AggregationSource | null
+  metadata?: Record<string, unknown>
+  refresh: () => Promise<void>
+}
+
+let sharedService: AggregationService | null = null
+
+export function setSharedAggregationService(service: AggregationService | null): void {
+  sharedService = service
+}
+
+export function getSharedAggregationService(): AggregationService | null {
+  return sharedService
+}
+
+export function usePrecomputedData<TData>(
+  userId: string | null | undefined,
+  type: AggregationType,
+  filters: FilterOptions,
+  options: UsePrecomputedDataOptions<TData> = {},
+): UsePrecomputedDataResult<TData> {
+  const service = options.service ?? sharedService
+  const [data, setData] = useState<TData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [source, setSource] = useState<AggregationSource | null>(null)
+  const [metadata, setMetadata] = useState<Record<string, unknown> | undefined>(undefined)
+
+  const filterSignature = useMemo(() => createFilterHash(filters), [
+    filters.timeframe,
+    filters.product,
+    (filters.topics ?? []).join('|'),
+    (filters.channels ?? []).join('|'),
+  ])
+
+  useEffect(() => {
+    if (!userId) {
+      setError('User ID is required to fetch pre-computed aggregations')
+      setLoading(false)
+      return
+    }
+
+    if (!service) {
+      setError('Aggregation service is not configured')
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await service.getAggregation<TData>({
+          userId,
+          type,
+          filters,
+          forceRefresh: options.forceRefresh,
+          fallbackCompute: options.fallbackCompute,
+        })
+
+        if (cancelled) {
+          return
+        }
+
+        setData(response.data)
+        setLastUpdated(response.computedAt)
+        setSource(response.source)
+        setMetadata(response.metadata)
+      } catch (err) {
+        if (cancelled) {
+          return
+        }
+
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        setError(message)
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    userId,
+    type,
+    filterSignature,
+    service,
+    options.forceRefresh,
+    options.fallbackCompute,
+  ])
+
+  const refresh = async () => {
+    if (!userId || !service) {
+      return
+    }
+    setLoading(true)
+
+    try {
+      const response = await service.refreshAggregation<TData>({
+        userId,
+        type,
+        filters,
+        fallbackCompute: options.fallbackCompute,
+      })
+
+      setData(response.data)
+      setLastUpdated(response.computedAt)
+      setSource(response.source)
+      setMetadata(response.metadata)
+      setError(null)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    lastUpdated,
+    source,
+    metadata,
+    refresh,
+  }
+}

--- a/scripts/backfill-aggregations.ts
+++ b/scripts/backfill-aggregations.ts
@@ -1,0 +1,58 @@
+import type { FilterOptions } from '@/lib/types'
+import type { AggregationService } from '@/services/aggregation-service'
+import type { AggregationType } from '@/services/types'
+
+export interface BackfillJobConfig {
+  service: AggregationService
+  userId: string
+  aggregationTypes: AggregationType[]
+  filters: FilterOptions[]
+  batchSize?: number
+  onProgress?: (info: BackfillProgressEvent) => void
+}
+
+export interface BackfillProgressEvent {
+  userId: string
+  aggregationType: AggregationType
+  filterIndex: number
+  totalFilters: number
+}
+
+export async function backfillPrecomputedAggregations(config: BackfillJobConfig): Promise<void> {
+  const { service, userId, aggregationTypes, filters, batchSize = 10, onProgress } = config
+
+  if (!filters.length || !aggregationTypes.length) {
+    return
+  }
+
+  let processed = 0
+
+  for (const filterChunk of chunk(filters, batchSize)) {
+    for (const type of aggregationTypes) {
+      for (const filter of filterChunk) {
+        await service.refreshAggregation({
+          userId,
+          type,
+          filters: filter,
+        })
+
+        processed += 1
+        onProgress?.({
+          userId,
+          aggregationType: type,
+          filterIndex: processed,
+          totalFilters: filters.length * aggregationTypes.length,
+        })
+      }
+    }
+  }
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  const safeSize = Math.max(1, size)
+  const result: T[][] = []
+  for (let index = 0; index < items.length; index += safeSize) {
+    result.push(items.slice(index, index + safeSize))
+  }
+  return result
+}

--- a/scripts/rollout-control.ts
+++ b/scripts/rollout-control.ts
@@ -1,0 +1,54 @@
+import { getAllFeatureFlags, isFeatureEnabled, resetRuntimeFeatureFlags, setRuntimeFeatureFlag } from '@/services/feature-flags'
+import type { FeatureFlagName } from '@/services/types'
+
+export interface RolloutInstruction {
+  flag: FeatureFlagName
+  enable: boolean
+  note?: string
+}
+
+export interface RolloutSummaryEntry {
+  flag: FeatureFlagName
+  enabled: boolean
+  source: string
+  note?: string
+}
+
+export interface RolloutSummary {
+  applied: RolloutSummaryEntry[]
+}
+
+export function applyRolloutPlan(plan: RolloutInstruction[]): RolloutSummary {
+  const applied: RolloutSummaryEntry[] = []
+
+  for (const instruction of plan) {
+    setRuntimeFeatureFlag(instruction.flag, instruction.enable)
+    const state = getAllFeatureFlags()[instruction.flag]
+
+    applied.push({
+      flag: instruction.flag,
+      enabled: state.enabled,
+      source: state.source,
+      note: instruction.note,
+    })
+  }
+
+  return { applied }
+}
+
+export function resetRolloutState(): void {
+  resetRuntimeFeatureFlags()
+}
+
+export function describeFlagState(flag: FeatureFlagName): RolloutSummaryEntry {
+  const state = getAllFeatureFlags()[flag]
+  return {
+    flag,
+    enabled: state.enabled,
+    source: state.source,
+  }
+}
+
+export function hasFlagChanged(flag: FeatureFlagName, expected: boolean): boolean {
+  return isFeatureEnabled(flag) === expected
+}

--- a/scripts/validate-migration.ts
+++ b/scripts/validate-migration.ts
@@ -1,0 +1,73 @@
+import type { FilterOptions } from '@/lib/types'
+import type { AggregationService } from '@/services/aggregation-service'
+import type { AggregationType } from '@/services/types'
+import { createFilterHash } from '@/services/types'
+
+export interface MigrationValidationConfig {
+  service: AggregationService
+  userId: string
+  aggregationTypes: AggregationType[]
+  filters: FilterOptions[]
+  onIssue?: (issue: MigrationValidationIssue) => void
+}
+
+export interface MigrationValidationIssue {
+  type: 'missing' | 'stale'
+  userId: string
+  aggregationType: AggregationType
+  filterHash: string
+  message: string
+}
+
+export interface MigrationValidationResult {
+  success: boolean
+  issues: MigrationValidationIssue[]
+}
+
+export async function validatePrecomputationMigration(
+  config: MigrationValidationConfig,
+): Promise<MigrationValidationResult> {
+  const { service, userId, aggregationTypes, filters, onIssue } = config
+  const issues: MigrationValidationIssue[] = []
+
+  for (const filter of filters) {
+    for (const aggregationType of aggregationTypes) {
+      try {
+        const response = await service.getAggregation({
+          userId,
+          type: aggregationType,
+          filters: filter,
+        })
+
+        if (response.expiresAt.getTime() <= Date.now()) {
+          const issue: MigrationValidationIssue = {
+            type: 'stale',
+            userId,
+            aggregationType,
+            filterHash: createFilterHash(filter),
+            message: 'Aggregation is expired and should be recomputed',
+          }
+
+          issues.push(issue)
+          onIssue?.(issue)
+        }
+      } catch (error) {
+        const issue: MigrationValidationIssue = {
+          type: 'missing',
+          userId,
+          aggregationType,
+          filterHash: createFilterHash(filter),
+          message: error instanceof Error ? error.message : 'Unknown error',
+        }
+
+        issues.push(issue)
+        onIssue?.(issue)
+      }
+    }
+  }
+
+  return {
+    success: issues.length === 0,
+    issues,
+  }
+}

--- a/services/CLAUDE.md
+++ b/services/CLAUDE.md
@@ -1,0 +1,23 @@
+# Services Directory
+
+## Purpose
+Shared service layer for backend-leaning functionality such as pre-computation, caching, storage adapters, and schedulers. Code here should stay framework-agnostic and rely on dependency injection for external resources.
+
+## Conventions
+- Keep modules focused on orchestration logic (no React code).
+- Export strongly typed classes or factory functions with clear interfaces.
+- Avoid side effects on import. Provide explicit `start`/`initialize` methods when needed.
+- Use lightweight utilities only (`Map`, `Set`, `Date`); defer heavy integrations to adapters passed in via constructor options.
+- Provide JSDoc for complex public APIs so hooks/components understand expected behavior.
+
+## Testing
+- Prefer unit tests close to business logic (to be added under `tests/unit/services/`).
+- Mock external dependencies through the provided interfaces.
+- Ensure deterministic behavior by injecting clock utilities when dealing with time.
+
+## Pitfalls
+1. Do not directly access Convex or Redis clients; wrap them behind interfaces.
+2. Do not mutate input filter objects; clone before modification.
+3. Do not use `any`. Define shared types in `services/types.ts`.
+4. Keep synchronous operations non-blocking; use async methods for IO boundaries.
+5. Document default configuration for each service class.

--- a/services/aggregation-service.ts
+++ b/services/aggregation-service.ts
@@ -1,0 +1,147 @@
+import { isFeatureEnabled } from './feature-flags'
+import { CacheManager } from './cache-manager'
+import { DataProcessor } from './data-processor'
+import { createFilterHash, defaultClock } from './types'
+import type {
+  AggregationEnvelope,
+  AggregationKey,
+  AggregationServiceRequest,
+  AggregationType,
+  Clock,
+} from './types'
+
+export type AggregationMetadataFactory = <TData>(
+  result: TData,
+  request: AggregationServiceRequest<TData>,
+) => Record<string, unknown> | undefined
+
+export interface AggregationServiceOptions {
+  cacheManager: CacheManager
+  dataProcessor: DataProcessor
+  clock?: Clock
+  defaultExpirationMs?: number
+  expirationOverrides?: Partial<Record<AggregationType, number>>
+  schemaVersion?: number
+  metadataFactory?: AggregationMetadataFactory
+}
+
+const DEFAULT_EXPIRATION_MS = 1000 * 60 * 15 // 15 minutes
+
+export class AggregationService {
+  private readonly cacheManager: CacheManager
+  private readonly dataProcessor: DataProcessor
+  private readonly clock: Clock
+  private readonly defaultExpirationMs: number
+  private readonly expirationOverrides: Partial<Record<AggregationType, number>>
+  private readonly schemaVersion: number
+  private readonly metadataFactory?: AggregationMetadataFactory
+
+  constructor(options: AggregationServiceOptions) {
+    this.cacheManager = options.cacheManager
+    this.dataProcessor = options.dataProcessor
+    this.clock = options.clock ?? defaultClock
+    this.defaultExpirationMs = options.defaultExpirationMs ?? DEFAULT_EXPIRATION_MS
+    this.expirationOverrides = options.expirationOverrides ?? {}
+    this.schemaVersion = options.schemaVersion ?? 1
+    this.metadataFactory = options.metadataFactory
+  }
+
+  async getAggregation<TData>(request: AggregationServiceRequest<TData>): Promise<AggregationEnvelope<TData>> {
+    if (!isFeatureEnabled('precomputationService')) {
+      return this.computeViaFallback(request)
+    }
+
+    const key = this.toKey(request)
+
+    if (!request.forceRefresh) {
+      const cached = await this.cacheManager.get<TData>(key)
+      if (cached) {
+        return cached.entry
+      }
+    }
+
+    return this.computeAndPersist(request, key)
+  }
+
+  async refreshAggregation<TData>(request: AggregationServiceRequest<TData>): Promise<AggregationEnvelope<TData>> {
+    const key = this.toKey(request)
+    return this.computeAndPersist(request, key)
+  }
+
+  async clearAggregation(request: AggregationServiceRequest<unknown>): Promise<void> {
+    const key = this.toKey(request)
+    await this.cacheManager.delete(key)
+  }
+
+  private async computeAndPersist<TData>(
+    request: AggregationServiceRequest<TData>,
+    key: AggregationKey,
+  ): Promise<AggregationEnvelope<TData>> {
+    try {
+      const data = await this.dataProcessor.compute<TData>(request.type, request.filters)
+      const envelope = this.buildEnvelope(data, request)
+      await this.cacheManager.set(key, envelope)
+      return envelope
+    } catch (error) {
+      if (request.fallbackCompute && isFeatureEnabled('precomputationFallbacks')) {
+        return this.computeViaFallback(request, error)
+      }
+
+      throw error
+    }
+  }
+
+  private async computeViaFallback<TData>(
+    request: AggregationServiceRequest<TData>,
+    reason?: unknown,
+  ): Promise<AggregationEnvelope<TData>> {
+    if (!request.fallbackCompute) {
+      throw new Error('Pre-computation fallback unavailable for this aggregation request')
+    }
+
+    const result = await request.fallbackCompute()
+    const envelope = this.buildEnvelope(result, request)
+    const baseMetadata = envelope.metadata ?? {}
+    const reasonValue =
+      reason instanceof Error ? reason.message : reason === undefined ? undefined : String(reason)
+
+    return {
+      ...envelope,
+      metadata: {
+        ...baseMetadata,
+        fallback: true,
+        ...(reasonValue ? { reason: reasonValue } : {}),
+      },
+    }
+  }
+
+  private buildEnvelope<TData>(
+    result: TData,
+    request: AggregationServiceRequest<TData>,
+  ): AggregationEnvelope<TData> {
+    const computedAt = new Date(this.clock.now())
+    const expiresAt = new Date(computedAt.getTime() + this.resolveExpirationMs(request.type))
+    const metadata = this.metadataFactory?.(result, request)
+
+    return {
+      data: result,
+      computedAt,
+      expiresAt,
+      version: this.schemaVersion,
+      metadata,
+      source: 'computed',
+    }
+  }
+
+  private resolveExpirationMs(type: AggregationType): number {
+    return this.expirationOverrides[type] ?? this.defaultExpirationMs
+  }
+
+  private toKey<TData>(request: AggregationServiceRequest<TData>): AggregationKey {
+    return {
+      userId: request.userId,
+      aggregationType: request.type,
+      filterHash: createFilterHash(request.filters),
+    }
+  }
+}

--- a/services/cache-manager.ts
+++ b/services/cache-manager.ts
@@ -1,0 +1,198 @@
+import { DEFAULT_CACHE_TTL_MS, defaultClock } from './types'
+import type {
+  AggregationEnvelope,
+  AggregationKey,
+  AggregationSource,
+  CacheRetrievalResult,
+  CachedAggregationEntry,
+  Clock,
+} from './types'
+import type { StorageLayer } from './storage-layer'
+
+export interface RedisClientLike {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, options?: { px?: number; ex?: number }): Promise<void>
+  del?(key: string): Promise<void>
+}
+
+export interface CacheManagerOptions {
+  clock?: Clock
+  redis?: RedisClientLike
+  storage?: StorageLayer<unknown>
+  defaultTtlMs?: number
+}
+
+export interface CacheGetOptions {
+  allowStale?: boolean
+}
+
+export interface CacheSetOptions {
+  persistToRedis?: boolean
+  persistToStorage?: boolean
+}
+
+export class CacheManager {
+  private readonly memoryCache = new Map<string, CachedAggregationEntry<unknown>>()
+  private readonly clock: Clock
+  private readonly redis?: RedisClientLike
+  private readonly storage?: StorageLayer<unknown>
+  private readonly defaultTtlMs: number
+
+  constructor(options: CacheManagerOptions = {}) {
+    this.clock = options.clock ?? defaultClock
+    this.redis = options.redis
+    this.storage = options.storage
+    this.defaultTtlMs = options.defaultTtlMs ?? DEFAULT_CACHE_TTL_MS
+  }
+
+  async get<TData = unknown>(
+    key: AggregationKey,
+    options: CacheGetOptions = {},
+  ): Promise<CacheRetrievalResult<TData> | null> {
+    const cacheKey = this.toCacheKey(key)
+    const now = this.clock.now()
+
+    const memoryEntry = this.memoryCache.get(cacheKey) as CachedAggregationEntry<TData> | undefined
+    if (memoryEntry && (options.allowStale || memoryEntry.expiresAt > now)) {
+      return {
+        entry: this.toEnvelope(memoryEntry, 'memory'),
+        hitLayer: 'memory',
+      }
+    }
+
+    if (memoryEntry && memoryEntry.expiresAt <= now) {
+      this.memoryCache.delete(cacheKey)
+    }
+
+    if (this.redis) {
+      const redisEntry = await this.getFromRedis<TData>(cacheKey, now, options.allowStale ?? false)
+      if (redisEntry) {
+        this.memoryCache.set(cacheKey, { ...redisEntry, source: 'memory' })
+        return {
+          entry: this.toEnvelope(redisEntry, 'redis'),
+          hitLayer: 'redis',
+        }
+      }
+    }
+
+    if (this.storage) {
+      const stored = await this.storage.getAggregation(key)
+      if (stored && (options.allowStale || stored.expiresAt.getTime() > now)) {
+        const entry = this.fromEnvelope(stored)
+        this.memoryCache.set(cacheKey, { ...entry, source: 'memory' })
+        return {
+          entry: stored as AggregationEnvelope<TData>,
+          hitLayer: 'storage',
+        }
+      }
+    }
+
+    return null
+  }
+
+  async set<TData = unknown>(
+    key: AggregationKey,
+    envelope: AggregationEnvelope<TData>,
+    options: CacheSetOptions = {},
+  ): Promise<void> {
+    const cacheKey = this.toCacheKey(key)
+    const entry = this.fromEnvelope(envelope)
+    entry.source = 'memory'
+    this.memoryCache.set(cacheKey, entry)
+
+    const ttlMs = Math.max(envelope.expiresAt.getTime() - this.clock.now(), 0)
+    const persistToRedis = options.persistToRedis ?? Boolean(this.redis)
+    const persistToStorage = options.persistToStorage ?? Boolean(this.storage)
+
+    if (persistToRedis && this.redis) {
+      await this.redis.set(cacheKey, JSON.stringify({ ...entry, source: 'redis' }), {
+        px: ttlMs || this.defaultTtlMs,
+      })
+    }
+
+    if (persistToStorage && this.storage) {
+      await this.storage.storeAggregation(key, envelope)
+    }
+  }
+
+  async delete(key: AggregationKey): Promise<void> {
+    const cacheKey = this.toCacheKey(key)
+    this.memoryCache.delete(cacheKey)
+
+    if (this.redis?.del) {
+      await this.redis.del(cacheKey)
+    }
+
+    if (this.storage) {
+      await this.storage.removeAggregation(key)
+    }
+  }
+
+  purgeExpired(): void {
+    const now = this.clock.now()
+    for (const [key, value] of this.memoryCache.entries()) {
+      if (value.expiresAt <= now) {
+        this.memoryCache.delete(key)
+      }
+    }
+  }
+
+  private async getFromRedis<TData>(
+    cacheKey: string,
+    now: number,
+    allowStale: boolean,
+  ): Promise<CachedAggregationEntry<TData> | null> {
+    if (!this.redis) {
+      return null
+    }
+
+    const raw = await this.redis.get(cacheKey)
+    if (!raw) {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as CachedAggregationEntry<TData>
+      if (allowStale || parsed.expiresAt > now) {
+        return { ...parsed, source: 'redis' }
+      }
+
+      if (this.redis.del) {
+        await this.redis.del(cacheKey)
+      }
+    } catch (error) {
+      console.warn('[cache-manager] Failed to parse redis cache entry', error)
+      if (this.redis.del) {
+        await this.redis.del(cacheKey)
+      }
+    }
+
+    return null
+  }
+
+  private toEnvelope<TData>(entry: CachedAggregationEntry<TData>, source: AggregationSource): AggregationEnvelope<TData> {
+    return {
+      data: entry.value,
+      computedAt: new Date(entry.computedAt),
+      expiresAt: new Date(entry.expiresAt),
+      version: entry.version,
+      metadata: entry.metadata,
+      source,
+    }
+  }
+
+  private fromEnvelope<TData>(envelope: AggregationEnvelope<TData>): CachedAggregationEntry<TData> {
+    return {
+      value: envelope.data,
+      computedAt: envelope.computedAt.getTime(),
+      expiresAt: envelope.expiresAt.getTime(),
+      version: envelope.version,
+      metadata: envelope.metadata,
+      source: envelope.source,
+    }
+  }
+
+  private toCacheKey(key: AggregationKey): string {
+    return `${key.userId}:${key.aggregationType}:${key.filterHash}`
+  }
+}

--- a/services/data-processor.ts
+++ b/services/data-processor.ts
@@ -1,0 +1,78 @@
+import type { FilterOptions, WatchRecord } from '@/lib/types'
+import { cloneFilters } from './types'
+import type {
+  AggregationComputeFn,
+  AggregationRegistration,
+  AggregationType,
+} from './types'
+
+export type FilterPreprocessor = (
+  filters: FilterOptions,
+) => Promise<FilterOptions> | FilterOptions
+
+export interface DataProcessorOptions {
+  loadRecords: (filters: FilterOptions) => Promise<WatchRecord[]>
+  preprocessors?: FilterPreprocessor[]
+}
+
+export class DataProcessor {
+  private readonly loadRecords: DataProcessorOptions['loadRecords']
+  private readonly preprocessors: FilterPreprocessor[]
+  private readonly registry = new Map<AggregationType, AggregationRegistration<unknown>>()
+
+  constructor(options: DataProcessorOptions) {
+    this.loadRecords = options.loadRecords
+    this.preprocessors = options.preprocessors ?? []
+  }
+
+  register<TData>(registration: AggregationRegistration<TData>): void {
+    this.registry.set(registration.type, registration as AggregationRegistration<unknown>)
+  }
+
+  registerMany(registrations: AggregationRegistration<unknown>[]): void {
+    registrations.forEach((registration) => this.registry.set(registration.type, registration))
+  }
+
+  hasAggregation(type: AggregationType): boolean {
+    return this.registry.has(type)
+  }
+
+  listAggregations(): AggregationType[] {
+    return [...this.registry.keys()]
+  }
+
+  async compute<TData>(type: AggregationType, filters: FilterOptions): Promise<TData> {
+    const registration = this.registry.get(type)
+
+    if (!registration) {
+      throw new Error(`No aggregation registered for type "${type}"`)
+    }
+
+    const preparedFilters = await this.runPreprocessors(filters)
+    const records = await this.loadRecords(preparedFilters)
+
+    const result = await (registration.compute as AggregationComputeFn<TData>)({
+      filters: preparedFilters,
+      records,
+    })
+
+    if (registration.validate) {
+      await registration.validate(result, {
+        filters: preparedFilters,
+        records,
+      })
+    }
+
+    return result
+  }
+
+  private async runPreprocessors(filters: FilterOptions): Promise<FilterOptions> {
+    let current = cloneFilters(filters)
+
+    for (const preprocessor of this.preprocessors) {
+      current = await preprocessor(current)
+    }
+
+    return current
+  }
+}

--- a/services/feature-flags.ts
+++ b/services/feature-flags.ts
@@ -1,0 +1,101 @@
+import { defaultClock } from './types'
+import type { Clock, FeatureFlagName, FeatureFlagState } from './types'
+
+const ENV_FLAG_KEY = 'NEXT_PUBLIC_PRECOMPUTATION_FLAGS'
+
+const DEFAULT_FLAG_VALUES: Record<FeatureFlagName, boolean> = {
+  precomputationService: false,
+  precomputationBackfill: false,
+  precomputationFallbacks: true,
+}
+
+function parseEnvFlags(): Partial<Record<FeatureFlagName, FeatureFlagState>> {
+  const raw =
+    typeof process !== 'undefined'
+      ? process.env[ENV_FLAG_KEY] ?? process.env[ENV_FLAG_KEY.replace('NEXT_PUBLIC_', '')]
+      : undefined
+
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<Record<FeatureFlagName, boolean>>
+    const now = Date.now()
+
+    return Object.entries(parsed).reduce<Partial<Record<FeatureFlagName, FeatureFlagState>>>(
+      (acc, [key, value]) => {
+        if (value === undefined) {
+          return acc
+        }
+
+        const flagName = key as FeatureFlagName
+        acc[flagName] = {
+          enabled: Boolean(value),
+          lastUpdated: now,
+          source: 'env',
+        }
+        return acc
+      },
+      {},
+    )
+  } catch (error) {
+    console.warn('[feature-flags] Failed to parse env flags:', error)
+    return {}
+  }
+}
+
+const envOverrides = parseEnvFlags()
+const runtimeOverrides = new Map<FeatureFlagName, FeatureFlagState>()
+
+function buildDefaultState(flag: FeatureFlagName, clock: Clock): FeatureFlagState {
+  return {
+    enabled: DEFAULT_FLAG_VALUES[flag],
+    lastUpdated: clock.now(),
+    source: 'default',
+  }
+}
+
+export function getFeatureFlagState(
+  flag: FeatureFlagName,
+  clock: Clock = defaultClock,
+): FeatureFlagState {
+  if (runtimeOverrides.has(flag)) {
+    return runtimeOverrides.get(flag)!
+  }
+
+  if (envOverrides[flag]) {
+    return envOverrides[flag]!
+  }
+
+  return buildDefaultState(flag, clock)
+}
+
+export function isFeatureEnabled(flag: FeatureFlagName): boolean {
+  return getFeatureFlagState(flag).enabled
+}
+
+export function setRuntimeFeatureFlag(
+  flag: FeatureFlagName,
+  enabled: boolean,
+  clock: Clock = defaultClock,
+): void {
+  runtimeOverrides.set(flag, {
+    enabled,
+    lastUpdated: clock.now(),
+    source: 'runtime',
+  })
+}
+
+export function resetRuntimeFeatureFlags(): void {
+  runtimeOverrides.clear()
+}
+
+export function getAllFeatureFlags(clock: Clock = defaultClock): Record<FeatureFlagName, FeatureFlagState> {
+  return (['precomputationService', 'precomputationBackfill', 'precomputationFallbacks'] as const).reduce<
+    Record<FeatureFlagName, FeatureFlagState>
+  >((acc, flag) => {
+    acc[flag] = getFeatureFlagState(flag, clock)
+    return acc
+  }, {} as Record<FeatureFlagName, FeatureFlagState>)
+}

--- a/services/storage-layer.ts
+++ b/services/storage-layer.ts
@@ -1,0 +1,89 @@
+import { createFilterHash, defaultClock } from './types'
+import type {
+  AggregationEnvelope,
+  AggregationKey,
+  Clock,
+  StorageLayerAdapter,
+  StoredAggregationRecord,
+} from './types'
+
+export interface StorageLayerOptions<TData = unknown> {
+  adapter: StorageLayerAdapter<TData>
+  clock?: Clock
+}
+
+export class StorageLayer<TData = unknown> {
+  private readonly adapter: StorageLayerAdapter<TData>
+  private readonly clock: Clock
+
+  constructor(options: StorageLayerOptions<TData>) {
+    this.adapter = options.adapter
+    this.clock = options.clock ?? defaultClock
+  }
+
+  async storeAggregation(key: AggregationKey, envelope: AggregationEnvelope<TData>): Promise<void> {
+    const record: StoredAggregationRecord<TData> = {
+      userId: key.userId,
+      aggregationType: key.aggregationType,
+      filterHash: key.filterHash,
+      data: envelope.data,
+      computedAt: envelope.computedAt.toISOString(),
+      expiresAt: envelope.expiresAt.toISOString(),
+      version: envelope.version,
+      metadata: envelope.metadata,
+    }
+
+    await this.adapter.store(record)
+  }
+
+  async getAggregation(key: AggregationKey): Promise<AggregationEnvelope<TData> | null> {
+    const stored = await this.adapter.fetch(key)
+
+    if (!stored) {
+      return null
+    }
+
+    return this.fromStoredRecord(stored)
+  }
+
+  async removeAggregation(key: AggregationKey): Promise<void> {
+    if (!this.adapter.remove) {
+      return
+    }
+
+    await this.adapter.remove(key)
+  }
+
+  async listExpired(referenceDate = new Date(this.clock.now())): Promise<AggregationKey[]> {
+    if (!this.adapter.fetchExpired) {
+      return []
+    }
+
+    const expired = await this.adapter.fetchExpired(referenceDate.toISOString())
+
+    return expired.map((record) => ({
+      userId: record.userId,
+      aggregationType: record.aggregationType,
+      filterHash: record.filterHash,
+    }))
+  }
+
+  createKey(userId: string, aggregationType: AggregationKey['aggregationType'], filters: Parameters<typeof createFilterHash>[0]): AggregationKey {
+    return {
+      userId,
+      aggregationType,
+      filterHash: createFilterHash(filters),
+    }
+  }
+
+  private fromStoredRecord(record: StoredAggregationRecord<TData>): AggregationEnvelope<TData> {
+    return {
+      data: record.data,
+      computedAt: new Date(record.computedAt),
+      expiresAt: new Date(record.expiresAt),
+      version: record.version,
+      metadata: record.metadata,
+      source: 'storage',
+    }
+  }
+}

--- a/services/types.ts
+++ b/services/types.ts
@@ -1,0 +1,147 @@
+import type { FilterOptions, WatchRecord } from '@/lib/types'
+
+export type AggregationType =
+  | 'kpi'
+  | 'monthly_trend'
+  | 'top_channels'
+  | 'day_time_heatmap'
+  | 'topics_leaderboard'
+  | 'session_analysis'
+  | 'viewing_patterns'
+  | 'enhanced_channel_metrics'
+  | 'channel_relationships'
+  | 'topic_evolution'
+  | (string & {})
+
+export type AggregationVersion = number
+
+export type AggregationSource = 'memory' | 'redis' | 'storage' | 'computed'
+
+export interface NormalizedFilterOptions {
+  timeframe: FilterOptions['timeframe']
+  product: FilterOptions['product']
+  topics: string[]
+  channels: string[]
+}
+
+export interface AggregationKey {
+  userId: string
+  aggregationType: AggregationType
+  filterHash: string
+}
+
+export interface CachedAggregationEntry<TData = unknown> {
+  value: TData
+  computedAt: number
+  expiresAt: number
+  version: AggregationVersion
+  metadata?: Record<string, unknown>
+  source: AggregationSource
+}
+
+export interface AggregationEnvelope<TData = unknown> {
+  data: TData
+  computedAt: Date
+  expiresAt: Date
+  version: AggregationVersion
+  metadata?: Record<string, unknown>
+  source: AggregationSource
+}
+
+export interface StoredAggregationRecord<TData = unknown> {
+  id?: string
+  userId: string
+  aggregationType: AggregationType
+  filterHash: string
+  data: TData
+  computedAt: string
+  expiresAt: string
+  version: AggregationVersion
+  metadata?: Record<string, unknown>
+}
+
+export interface AggregationComputeContext {
+  filters: FilterOptions
+  records: WatchRecord[]
+}
+
+export type AggregationComputeFn<TData = unknown> = (
+  context: AggregationComputeContext,
+) => Promise<TData> | TData
+
+export type AggregationValidationFn<TData = unknown> = (
+  result: TData,
+  context: AggregationComputeContext,
+) => Promise<void> | void
+
+export interface AggregationRegistration<TData = unknown> {
+  type: AggregationType
+  compute: AggregationComputeFn<TData>
+  validate?: AggregationValidationFn<TData>
+}
+
+export interface Clock {
+  now(): number
+}
+
+export const defaultClock: Clock = {
+  now: () => Date.now(),
+}
+
+export type FeatureFlagName =
+  | 'precomputationService'
+  | 'precomputationBackfill'
+  | 'precomputationFallbacks'
+
+export interface FeatureFlagState {
+  enabled: boolean
+  lastUpdated: number
+  source: 'default' | 'env' | 'runtime'
+}
+
+export interface AggregationServiceRequest<TData = unknown> {
+  userId: string
+  type: AggregationType
+  filters: FilterOptions
+  forceRefresh?: boolean
+  fallbackCompute?: () => Promise<TData>
+}
+
+export interface CacheRetrievalResult<TData = unknown> {
+  entry: AggregationEnvelope<TData>
+  hitLayer: AggregationSource
+}
+
+export interface StorageLayerAdapter<TData = unknown> {
+  store(record: StoredAggregationRecord<TData>): Promise<void>
+  fetch(
+    key: AggregationKey,
+  ): Promise<StoredAggregationRecord<TData> | null>
+  remove?(key: AggregationKey): Promise<void>
+  fetchExpired?(beforeIso: string): Promise<StoredAggregationRecord<TData>[]>
+}
+
+export const DEFAULT_CACHE_TTL_MS = 1000 * 60 * 15 // 15 minutes
+
+export function normalizeFilters(filters: FilterOptions): NormalizedFilterOptions {
+  return {
+    timeframe: filters.timeframe,
+    product: filters.product,
+    topics: [...(filters.topics ?? [])].sort(),
+    channels: [...(filters.channels ?? [])].sort(),
+  }
+}
+
+export function createFilterHash(filters: FilterOptions): string {
+  const normalized = normalizeFilters(filters)
+  return JSON.stringify(normalized)
+}
+
+export function cloneFilters(filters: FilterOptions): FilterOptions {
+  return {
+    timeframe: filters.timeframe,
+    product: filters.product,
+    topics: filters.topics ? [...filters.topics] : undefined,
+    channels: filters.channels ? [...filters.channels] : undefined,
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold the precomputation service layer with typed aggregation orchestration, caching, storage adapters, and feature flag controls
- Add reusable React hooks and Convex endpoints/schema to fetch timestamped aggregation results through the new service pipeline
- Provide scripts for aggregation backfill, migration validation, and rollout management ahead of later implementation phases

## Testing
- `npm run lint` *(fails: command prompts for interactive ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd489dad48322a503332cfac55dae